### PR TITLE
1 s mount delay

### DIFF
--- a/systemd/system/mount-sd@.service
+++ b/systemd/system/mount-sd@.service
@@ -16,7 +16,7 @@ RemainAfterExit=yes
 # "udisksd" (per "udisks2.service") has finished starting, because
 # the udisks object for a partition has not been created yet, one
 # may give udisksd a second to settle:
-# ExecStartPre=/bin/sleep 1
+ExecStartPre=/bin/sleep 1
 ExecStart=/usr/bin/udisksctl-user mount -b /dev/%i
 ExecStop=/usr/bin/udisksctl-user unmount -b /dev/%i
 


### PR DESCRIPTION
Add a 1 second mount delay (as in [*crypto-scdard*](https://github.com/Olf0/crypto-sdcard/blob/master/systemd/system/mount-cryptosd-luks%40.service#L19)) in order to ensure reliable mounting on fast devices, although the timing constraints seem to be much more relaxed compared to *crypto-sdcard* (i.e. this is rather a precautions measure than a known necessity for *mount-sdcard*, in contrast to *crypto-sdcard*).